### PR TITLE
Handle multiple extracted versions of same webjar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,8 +14,9 @@ developers += Developer(
 addSbtJsEngine("1.3.5")
 
 libraryDependencies ++= Seq(
-  "org.webjars.npm" % "coffeescript" % "2.7.0",
-  "org.webjars" % "mkdirp" % "0.5.0"
+  "org.webjars.npm" % "node-require-fallback" % "1.0.0",
+  "org.webjars.npm" % "coffeescript" % "2.7.0", // sync with src/main/resources/coffee.js
+  "org.webjars" % "mkdirp" % "0.5.0", // sync with src/main/resources/coffee.js
 )
 
 // Customise sbt-dynver's behaviour to make it work with tags which aren't v-prefixed

--- a/src/main/resources/coffee.js
+++ b/src/main/resources/coffee.js
@@ -5,9 +5,10 @@
     "use strict";
 
     var args = process.argv,
+        requireIfExists = require('node-require-fallback'),
         fs = require("fs"),
-        coffeeScript = require("coffeescript"),
-        mkdirp = require("mkdirp"),
+        coffeeScript = requireIfExists("coffeescript/2.7.0", "coffeescript"), // sync with build.sbt
+        mkdirp = requireIfExists("mkdirp/0.5.0", "mkdirp"), // sync with build.sbt
         path = require("path");
 
     var SOURCE_FILE_MAPPINGS_ARG = 2;

--- a/src/sbt-test/sbt-coffeescript-plugin/coffee-same-webjars-different-version/build.sbt
+++ b/src/sbt-test/sbt-coffeescript-plugin/coffee-same-webjars-different-version/build.sbt
@@ -1,0 +1,22 @@
+lazy val root = (project in file(".")).enablePlugins(SbtWeb)
+
+val checkMapFileContents = taskKey[Unit]("check that map contents are correct")
+
+checkMapFileContents := {
+  val contents = IO.read((Assets / WebKeys.public).value / "coffee" / "a.js.map")
+  if (contents != """{
+                    |  "version": 3,
+                    |  "file": "a.js",
+                    |  "sourceRoot": "",
+                    |  "sources": [
+                    |    "a.coffee"
+                    |  ],
+                    |  "names": [],
+                    |  "mappings": "AAAA;AAAA,MAAA,MAAA,EAAA;;EAAA,MAAA,GAAW;;EACX,QAAA,GAAW;AADX",
+                    |  "sourcesContent": [
+                    |    "number   = 42\nopposite = true\n"
+                    |  ]
+                    |}""".stripMargin) {
+    sys.error(s"Unexpected contents: $contents")
+  }
+}

--- a/src/sbt-test/sbt-coffeescript-plugin/coffee-same-webjars-different-version/project/plugins.sbt
+++ b/src/sbt-test/sbt-coffeescript-plugin/coffee-same-webjars-different-version/project/plugins.sbt
@@ -1,0 +1,25 @@
+sys.props.get("project.version") match {
+  case Some(x) => addSbtPlugin("com.github.sbt" % "sbt-coffeescript" % x)
+  case _ => sys.error("""|The system property 'project.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}
+
+// When the same webjar (= same name) from different groupIds (org.webjars[.npm|bower]?)
+// are are on the classpath, those webjars get extracted into subfolders which are named by the version of the webjar.
+// However, if there is just one type (npm, bower, classic) of a webjar on the classpath, NO subfolders gets created.
+// Now, because in a project we don't know which other webjars get pulled in from other dependencies, it can happen
+// that subfolders get created, or may not. However, require(...) can't know that and therefore has to look in both places.
+// To test that the lookup is correct, we force this scripted test to create subfolders by pulling in the same webjar
+// but from different groupIds (the other scripted test does not do that and therefore no subfolders get created there)
+// btw: dependency eviction within the same type of webjar still works correctly, so e.g. 0.2 wins over 0.1 within the same type of webjar
+// and no subfolder will be forced for that case but the newest version will be choosen. Like normal dependency resolution.
+libraryDependencies ++= Seq(
+  // Pulling in the classic and the npm webjar to subfolders for this webjar will be created
+  "org.webjars" % "mkdirp" % "0.3.5",
+  "org.webjars.npm" % "mkdirp" % "0.5.1",
+
+  // Same here, we pull in the bower and the npm one so subfolders will be created
+  // ("1.9.2/ and 2.5.1 etc.)
+  "org.webjars.bower" % "coffeescript" % "1.9.2",
+  "org.webjars.npm" % "coffeescript" % "2.5.1",
+)

--- a/src/sbt-test/sbt-coffeescript-plugin/coffee-same-webjars-different-version/src/main/assets/coffee/a.coffee
+++ b/src/sbt-test/sbt-coffeescript-plugin/coffee-same-webjars-different-version/src/main/assets/coffee/a.coffee
@@ -1,0 +1,2 @@
+number   = 42
+opposite = true

--- a/src/sbt-test/sbt-coffeescript-plugin/coffee-same-webjars-different-version/test
+++ b/src/sbt-test/sbt-coffeescript-plugin/coffee-same-webjars-different-version/test
@@ -1,0 +1,8 @@
+# Compile a CoffeeScript file
+
+> assets
+$ exists target/web/public/main/coffee/a.js
+$ exists target/web/public/main/coffee/a.js.map
+
+> checkMapFileContents
+


### PR DESCRIPTION
Those webjars get extracted in subfolders.

See lengthy comment in `plugins.sbt` of this pull request.